### PR TITLE
Add test for game.js and update lint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,16 @@
+{
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2021": true,
+    "jest": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "rules": {
+    "no-case-declarations": "off"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -431,15 +431,28 @@ function togglePause() {
     gameState.isPaused = !gameState.isPaused;
 }
 
-// Speed control
-const speedSlider = document.getElementById('speedSlider');
-const speedValue = document.getElementById('speedValue');
+// Expose controls in the browser and start the game unless running under test
+if (typeof window !== 'undefined') {
+    window.resetGame = resetGame;
+    window.togglePause = togglePause;
 
-speedSlider.addEventListener('input', (e) => {
-    gameState.speedMultiplier = parseFloat(e.target.value);
-    speedValue.textContent = gameState.speedMultiplier.toFixed(1) + 'x';
-});
+    const speedSlider = document.getElementById('speedSlider');
+    const speedValue = document.getElementById('speedValue');
 
-// Initialize game
-initPlayers();
-gameLoop();
+    if (speedSlider && speedValue) {
+        speedSlider.addEventListener('input', (e) => {
+            gameState.speedMultiplier = parseFloat(e.target.value);
+            speedValue.textContent = gameState.speedMultiplier.toFixed(1) + 'x';
+        });
+    }
+
+    if (!window.__TEST__) {
+        initPlayers();
+        gameLoop();
+    }
+}
+
+// Export for testing
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { initPlayers, gameState };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "soccerdoodle",
+  "version": "1.0.0",
+  "description": "Soccer Doodle Game",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest",
+    "lint": "eslint assets/**/*.js tests/**/*.js"
+  },
+  "devDependencies": {
+    "eslint": "^8.0.0",
+    "jest": "^29.0.0",
+    "jest-environment-jsdom": "^30.0.4"
+  }
+}

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -1,0 +1,16 @@
+/**
+ * @jest-environment jsdom
+ */
+
+global.__TEST__ = true;
+
+document.body.innerHTML = '<canvas id="gameCanvas"></canvas>';
+const canvas = document.getElementById('gameCanvas');
+canvas.getContext = jest.fn(() => ({}));
+
+const { initPlayers, gameState } = require('../assets/js/game');
+
+test('initPlayers creates 10 players', () => {
+  initPlayers();
+  expect(gameState.players.length).toBe(10);
+});


### PR DESCRIPTION
## Summary
- remove example utility module and its tests
- export `initPlayers` and `gameState` from `game.js`
- prevent the game loop from running during tests
- adjust ESLint configuration and lint script
- add Jest test for `game.js`

## Testing
- `npm run lint --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6873b210d73083238185a2cafeb86a89